### PR TITLE
Agrega descripción del sito a la metadata.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,11 +20,8 @@
 
 title: Portal de la Política de Datos de la Ciudad de México
 email: your-email@example.com
-description: >- # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
-baseurl: "/politicadedatos" 
+description: Portal de la Política de Gestión de Datos de la Ciudad de México
+aseurl: "/politicadedatos" 
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll

--- a/_sass/_config.yml
+++ b/_sass/_config.yml
@@ -20,10 +20,7 @@
 
 title: Portal de la Política de Datos de la Ciudad de México
 email: your-email@example.com
-description: >- # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+description: Portal de la Política de Gestión de Datos de la Ciudad de México
 baseurl: "/micrositio_adip" 
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb


### PR DESCRIPTION
"Portal de la Política de Gestión de Datos de la Ciudad de México" sería la nueva descripción. 
Ejemplo de como se ve la descripción actual en un servicio de mensajería instantánea al compartir el enlace.  

![2020-11-12_20-11-1605235744](https://user-images.githubusercontent.com/28630268/99023091-829ac500-2529-11eb-94ec-27a89c4c3bd7.png)
